### PR TITLE
add GH action to deploy and invalidate cache

### DIFF
--- a/.github/workflows/deploy-and-invalidate.yaml
+++ b/.github/workflows/deploy-and-invalidate.yaml
@@ -1,0 +1,30 @@
+name: Upload custom Element
+
+on:
+  push:
+    branches:
+    - production
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: AWS s3 sync
+    - uses: actions/checkout@master
+    - uses: jakejarvis/s3-sync-action@master
+      with:
+        args: --acl public-read --follow-symlinks --delete
+      env:
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: 'us-west-2'
+        SOURCE_DIR: 'dist'
+    - name: Invalidate Cloudfront cache
+    - uses: chetan/invalidate-cloudfront-action@v2
+      env:
+        DISTRIBUTION: ${{ secrets.DISTRIBUTION }}
+        PATHS: "/*"
+        AWS_REGION: "us-west-2"
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
- add a Github Action that does the following

aws s3 sync --delete --acl 'public-read' './dist/' '<bucket>'
aws cloudfront create-invalidation --distribution-id '<distribution-id>' --paths '/*'
